### PR TITLE
CLI monitor が失敗する

### DIFF
--- a/lib/furikake/monitor.rb
+++ b/lib/furikake/monitor.rb
@@ -3,6 +3,7 @@
 module Furikake
   class Monitor < Report
     def initialize(options)
+      super(true)
       $stdout.sync = true
       @logger = Logger.new($stdout)
       @flag_int = false


### PR DESCRIPTION
## Description

CLIでのmonitor実行が失敗します。
#43 での引数追加の影響と思われるます。

## Tested

* .furikake.yml が無い状態

```
$ bundle exec furikake version
0.2.0
$ bundle exec furikake show
E, [2020-09-21T16:41:39.025388 #84260] ERROR -- : .furikake.yml が存在していません.
$ ls .furikake.yml
ls: .furikake.yml: No such file or directory
$ bundle exec furikake monitor -i 1
I, [2020-09-21T16:42:06.585243 #84322]  INFO -- : furikake monitor を起動します.
E, [2020-09-21T16:42:07.587913 #84322] ERROR -- : monitor の起動に失敗しました. undefined method `[]' for nil:NilClass
$
```

* .furikake.yml がある状態
    * show/publish は成功するが、 monitor は失敗する

```
$ bundle exec furikake setup
[setup] creating .furikake.yml...
[setup] .furikake.yml created.
[setup] .furikake.yml already exists.
[setup] create `addons` directory? [y/n]
n
[setup] `addons` directory not created.
$ ls .furikake.yml
.furikake.yml
$ bundle exec furikake show
I, [2020-09-21T16:46:09.888999 #85242]  INFO -- : リソースタイプ: alb の情報を取得しました.
・・・略

$ bundle exec furikake monitor -i 1
I, [2020-09-21T16:47:07.098701 #85283]  INFO -- : furikake monitor を起動します.
E, [2020-09-21T16:47:08.104524 #85283] ERROR -- : monitor の起動に失敗しました. undefined method `[]' for nil:NilClass
$
```

* 修正後

```
$ bundle exec furikake monitor -i 1
I, [2020-09-21T17:12:04.502627 #87272]  INFO -- : furikake monitor を起動します.
```
